### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -28,12 +28,16 @@ global.sleep = (time: number) => {
 export function showProductReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     // Truncate id to avoid unintentional RCE
-    const id = !utils.isChallengeEnabled(challenges.noSqlCommandChallenge) ? Number(req.params.id) : utils.trunc(req.params.id, 40)
+    const challengeEnabled = utils.isChallengeEnabled(challenges.noSqlCommandChallenge)
+    const id = challengeEnabled ? utils.trunc(req.params.id, 40) : Number(req.params.id)
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
+    const query = challengeEnabled
+      ? { $where: 'this.product == ' + id }
+      : { product: id }
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find(query).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/gjvoeg/juice-shop-ada1466/security/code-scanning/53](https://github.com/gjvoeg/juice-shop-ada1466/security/code-scanning/53)

To fix this issue, eliminate the use of the `$where` clause with user input unless it is absolutely necessary and guaranteed safe. Instead, perform a direct lookup using a query operator (`product: <id>`), providing the value as a parameter, avoiding the risk of code injection. This change should be implemented in `routes/showProductReviews.ts`, specifically in the query for reviews on line 36. If there is a challenge (like `noSqlCommandChallenge`) that relies on this injection vector, you may want to handle it separately with caution—for general cases, you should always use parameterized queries or validate/sanitize to restrict input to safe types (e.g., numbers).

To implement this fix:
- On line 31, ensure that `id` is converted to a number (if applicable).
- Change the query in line 36 from using `$where` to using a direct equality match.
- If supporting a challenge, consider checking if the challenge is enabled and continue using the vulnerable query, but in all other cases, use the safe query.
- No new methods or imports are required; just change the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
