### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/gjvoeg/juice-shop-ada1466/security/code-scanning/54](https://github.com/gjvoeg/juice-shop-ada1466/security/code-scanning/54)

The best way to fix this code injection issue is to avoid using MongoDB's `$where` operator with user-supplied input, as `$where` allows execution of arbitrary JavaScript. Instead, a safe query should use direct, field-based comparison using standard MongoDB query operators, such as `{ orderId: id }`. Specifically, replace the use of `$where` with `{ orderId: id }`, which will safely find orders by their `orderId` fields with no code evaluation, completely avoiding the risk of code injection. 

To implement the fix, update line 18 in the `trackOrder` function in routes/trackOrder.ts to replace the call to `db.ordersCollection.find({ $where: ... })` with `db.ordersCollection.find({ orderId: id })`. No other changes to imports or methods are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
